### PR TITLE
fixed broken parsing of Websocket Extensions if server side is a Tomcat 8.0 instance

### DIFF
--- a/PocketSocket/PSWebSocketDriver.m
+++ b/PocketSocket/PSWebSocketDriver.m
@@ -256,7 +256,7 @@ typedef NS_ENUM(NSInteger, PSWebSocketDriverState) {
     }
     
     // validate extensions
-    NSArray *extensionComponents = [headers[@"Sec-WebSocket-Extensions"] componentsSeparatedByString:@"; "];
+    NSArray *extensionComponents = [headers[@"Sec-WebSocket-Extensions"] componentsSeparatedByString:@";"];
     if(![self pmdConfigureWithExtensionsHeaderComponents:extensionComponents]) {
         [self failWithErrorCode:PSWebSocketErrorCodeHandshakeFailed reason:@"invalid permessage-deflate extension parameters"];
         return;
@@ -469,7 +469,7 @@ typedef NS_ENUM(NSInteger, PSWebSocketDriverState) {
             }
             
             // extensions
-            NSArray *extensionComponents = [headers[@"Sec-WebSocket-Extensions"] componentsSeparatedByString:@"; "];
+            NSArray *extensionComponents = [headers[@"Sec-WebSocket-Extensions"] componentsSeparatedByString:@";"];
             
             // per-message deflate
             if(![self pmdConfigureWithExtensionsHeaderComponents:extensionComponents]) {
@@ -853,17 +853,19 @@ typedef NS_ENUM(NSInteger, PSWebSocketDriverState) {
     
     for(NSString *component in components) {
         // split to key & value
-        NSArray *subcomponents = [component componentsSeparatedByString:@"="];
+        NSString *trimmedComponent = [component stringByTrimmingCharactersInSet:
+                                      [NSCharacterSet whitespaceAndNewlineCharacterSet]];
+        NSArray *subcomponents = [trimmedComponent componentsSeparatedByString:@"="];
         
-        if([component isEqualToString:@"permessage-deflate"]) {
+        if([trimmedComponent isEqualToString:@"permessage-deflate"]) {
             _pmdEnabled = YES;
-        } else if([component isEqualToString:@"client_max_window_bits"] && subcomponents.count > 1) {
+        } else if([trimmedComponent isEqualToString:@"client_max_window_bits"] && subcomponents.count > 1) {
             _pmdClientWindowBits = -[subcomponents[0] integerValue];
-        } else if([component isEqualToString:@"server_max_window_bits"] && subcomponents.count > 1) {
+        } else if([trimmedComponent isEqualToString:@"server_max_window_bits"] && subcomponents.count > 1) {
             _pmdServerWindowBits = -[subcomponents[0] integerValue];
-        } else if([component isEqualToString:@"client_no_context_takeover"] && _mode == PSWebSocketModeClient) {
+        } else if([trimmedComponent isEqualToString:@"client_no_context_takeover"] && _mode == PSWebSocketModeClient) {
             _pmdClientNoContextTakeover = YES;
-        } else if([component isEqualToString:@"server_no_context_takeover"] && _mode == PSWebSocketModeClient) {
+        } else if([trimmedComponent isEqualToString:@"server_no_context_takeover"] && _mode == PSWebSocketModeClient) {
             _pmdServerNoContextTakeover = YES;
         }
     }


### PR DESCRIPTION
While parsing the **Sec-WebSocket-Extensions** PocketSocket assumes the Extensions are separated with a ";" followed with a blank, this is not the case for tomcat and is as far as I can see no requirement. In my case this lead to a wrongly configured "permessage-deflate", as the server assumed the client wants permessage-deflate but the client failed parsing the server response send by Tomcat 8.0:

```
Sec-WebSocket-Extensions : permessage-deflate;client_max_window_bits=15
```

and assumes the server doesn't support **permessage-deflate** and fails parsing data send from the server. The change fixes this by removing the blank and trimming the extension string before comparing.