### PR TITLE
Add subspecs to Podspec to allow modular usage

### DIFF
--- a/PocketSocket.podspec
+++ b/PocketSocket.podspec
@@ -12,9 +12,23 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '6.0'
   s.osx.deployment_target = '10.8'
 
-  s.public_header_files = 'PocketSocket/PSWebSocket.h', 'PocketSocket/PSWebSocketDriver.h', 'PocketSocket/PSWebSocketTypes.h', 'PocketSocket/PSWebSocketServer.h'
-  s.source_files = 'PocketSocket/PS*.{h,m,c}'
-  
-  s.frameworks = 'CFNetwork', 'Foundation', 'Security'
-  s.libraries = 'z', 'system'
+  s.subspec 'Core' do |ss|
+    ss.public_header_files = 'PocketSocket/PSWebSocketDriver.h', 'PocketSocket/PSWebSocketTypes.h'
+    ss.source_files = 'PocketSocket/PSWebSocketDriver.{h,m}', 'PocketSocket/PSWebSocketTypes.{h,m}', 'PocketSocket/PSWebSocketBuffer.{h,m}', 'PocketSocket/PSWebSocketDeflater.{h,m}', 'PocketSocket/PSWebSocketInflater.{h,m}', 'PocketSocket/PSWebSocketUTF8Decoder.{h,m}', 'PocketSocket/PSWebSocketInternal.h'
+
+    ss.frameworks = 'CFNetwork', 'Foundation', 'Security'
+    ss.libraries = 'z', 'system'
+  end
+
+  s.subspec 'Client' do |ss|
+    ss.dependency 'PocketSocket/Core'
+    ss.public_header_files = 'PocketSocket/PSWebSocket.h'
+    ss.source_files = 'PocketSocket/PSWebSocket.{h,m}', 'PocketSocket/PSWebSocketNetworkThread.{h,m}'
+  end
+
+  s.subspec 'Server' do |ss|
+    ss.dependency 'PocketSocket/Client'
+    ss.public_header_files = 'PocketSocket/PSWebSocketServer.h'
+    ss.source_files = 'PocketSocket/PSWebSocketServer.{h,m}'
+  end
 end


### PR DESCRIPTION
I have broken the Podspec into three subspecs: `Core`, `Client` and `Server`.

This allows the three major components (as [mentioned in the README](https://github.com/zwopple/PocketSocket#major-components)) to be used separately as needed.

All 3 subspecs are included by default so there will be no change for existing users.

I checked and the Podspec still validates.
