### PR TITLE
inflateInit2(&_stream, -MAX_WBITS)

### DIFF
--- a/PocketSocket/PSWebSocketInflater.m
+++ b/PocketSocket/PSWebSocketInflater.m
@@ -95,7 +95,7 @@
 
 - (BOOL)ensureReady:(NSError *__autoreleasing *)outError {
     if(!_ready) {
-        if(inflateInit2(&_stream, _windowBits) != Z_OK) {
+        if(inflateInit2(&_stream, -MAX_WBITS) != Z_OK) {
             PSWebSocketSetOutError(outError, PSWebSocketStatusCodeProtocolError, @"Failed to initialize inflate stream");
             return NO;
         }


### PR DESCRIPTION
On some instances headers are missing and inflateInit2 fails.

This fix can also be applied on the development branch:

http://stackoverflow.com/questions/18700656/zlib-inflate-failing-with-3-z-data-error

Inflate() was failing because it was looking for GZip headers which were not present. If you initialize the stream with:

ret = inflateInit2(&strm, -MAX_WBITS);
Passing a negative window bits value prevents inflate from checking for gzip or zlib headers and unzipping works as expected.