### PR TITLE
Only attempt custom SSL evaluation if webSocket:evaluateServerTrust: is implemented in the delegate

### DIFF
--- a/PocketSocket/PSWebSocket.m
+++ b/PocketSocket/PSWebSocket.m
@@ -279,7 +279,6 @@
 
 - (void)connect {
     if(_secure && _mode == PSWebSocketModeClient) {
-        _negotiatedSSL = NO;
         
         __block BOOL customTrustEvaluation = NO;
         [self executeDelegateAndWait:^{
@@ -289,7 +288,10 @@
         NSMutableDictionary *ssl = [NSMutableDictionary dictionary];
         ssl[(__bridge id)kCFStreamSSLLevel] = (__bridge id)kCFStreamSocketSecurityLevelNegotiatedSSL;
         if(customTrustEvaluation) {
+            _negotiatedSSL = NO;
             ssl[(__bridge id)kCFStreamSSLValidatesCertificateChain] = @NO;
+        } else {
+            _negotiatedSSL = YES;
         }
         
         [_outputStream setProperty:ssl forKey:(__bridge id)kCFStreamPropertySSLSettings];


### PR DESCRIPTION
I'm not 100% sure if this is the correct approach, but it fixed my problem connecting to wss sockets due to an unimplemented webSocket:evaluateServerTrust: always failing and kCFStreamSSLValidatesCertificateChain being set to NO.