### PR TITLE
Remove recursive gitmodule entry

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "pages"]
-	path = pages
-	url = git://github.com/zwopple/PocketSocket.git


### PR DESCRIPTION
Right now, this repo contains a .gitmodule entry that references itself. As far as I can tell, it's unused. Let me know if this isn't the case. Thanks!
